### PR TITLE
Fix "Implement auto-dctest with slack-notifier"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,18 +43,18 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: Update image on neco-test
-          command: |
-            echo $GCLOUD_SERVICE_ACCOUNT_NECO_TEST > account_test.json
-            gcloud auth activate-service-account --key-file=account_test.json
-            /tmp/workspace/necogcp neco-test create-image
-          no_output_timeout: 20m
-      - run:
           name: Update image on neco-dev
           command: |
             echo $GCLOUD_SERVICE_ACCOUNT_NECO_DEV > account_dev.json
             gcloud auth activate-service-account --key-file=account_dev.json
             /tmp/workspace/necogcp neco-test create-image --project-id neco-dev
+          no_output_timeout: 20m
+      - run:
+          name: Update image on neco-test
+          command: |
+            echo $GCLOUD_SERVICE_ACCOUNT_NECO_TEST > account_test.json
+            gcloud auth activate-service-account --key-file=account_test.json
+            /tmp/workspace/necogcp neco-test create-image
           no_output_timeout: 20m
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
     working_directory: /work
     steps:
       - checkout
+      - run: make setup
       - run: make build-necogcp
       - persist_to_workspace:
           root: ./build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
           command: |
             echo $GCLOUD_SERVICE_ACCOUNT_NECO_DEV > account_dev.json
             gcloud auth activate-service-account --key-file=account_dev.json
-            /tmp/workspace/necogcp neco-test create-image --project neco-dev
+            /tmp/workspace/necogcp neco-test create-image --project-id neco-dev
           no_output_timeout: 20m
       - run:
           name: Update image on neco-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,18 +43,18 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: Update image on neco-dev
-          command: |
-            echo $GCLOUD_SERVICE_ACCOUNT_NECO_DEV > account_dev.json
-            gcloud auth activate-service-account --key-file=account_dev.json
-            /tmp/workspace/necogcp neco-test create-image --project-id neco-dev
-          no_output_timeout: 20m
-      - run:
           name: Update image on neco-test
           command: |
             echo $GCLOUD_SERVICE_ACCOUNT_NECO_TEST > account_test.json
             gcloud auth activate-service-account --key-file=account_test.json
             /tmp/workspace/necogcp neco-test create-image
+          no_output_timeout: 20m
+      - run:
+          name: Update image on neco-dev
+          command: |
+            echo $GCLOUD_SERVICE_ACCOUNT_NECO_DEV > account_dev.json
+            gcloud auth activate-service-account --key-file=account_dev.json
+            /tmp/workspace/necogcp neco-test create-image --project-id neco-dev
           no_output_timeout: 20m
 
 workflows:

--- a/Makefile.dctest
+++ b/Makefile.dctest
@@ -7,11 +7,11 @@ LOG_LEVEL ?= info
 
 SERVICE_FUNC_ACCOUNT_NAME := auto-dctest-function
 SERVICE_FUNC_ACCOUNT_EMAIL := $(SERVICE_FUNC_ACCOUNT_NAME)@$(GCP_PROJECT).iam.gserviceaccount.com
-SERVICE_FUNC_ACCOUNT_DISPNAME := "VM instance create/delete function"
+SERVICE_FUNC_ACCOUNT_DISPNAME := "For function to create/delete VM instance"
 
 SERVICE_VM_ACCOUNT_NAME := auto-dctest-vminstance
 SERVICE_VM_ACCOUNT_EMAIL := $(SERVICE_VM_ACCOUNT_NAME)@$(GCP_PROJECT).iam.gserviceaccount.com
-SERVICE_VM_ACCOUNT_DISPNAME := "VM instance itself to bootstrap neco/neco-apps"
+SERVICE_VM_ACCOUNT_DISPNAME := "For VM instance to bootstrap neco/neco-apps"
 
 TOPIC_NAME := auto-dctest-events
 FUNCTION_NAME := auto-dctest
@@ -22,7 +22,8 @@ FORCE_DELETING_SCHEDULER_NAME := force-delete-dctest
 
 init: \
 	enable-api \
-	create-service-account \
+	create-function-service-account \
+	create-compute-service-account \
 	deploy-function \
 	create-deleting-scheduler \
 	create-force-deleting-scheduler
@@ -35,7 +36,8 @@ list-teams:
 delete-team: delete-creating-scheduler
 
 clean: \
-	delete-service-account \
+	delete-function-service-account \
+	delete-compute-service-account \
 	delete-function \
 	delete-deleting-scheduler \
 	delete-force-deleting-scheduler
@@ -47,7 +49,7 @@ enable-api:
 	gcloud services enable --project $(GCP_PROJECT) cloudscheduler.googleapis.com
 	gcloud services enable --project $(GCP_PROJECT) cloudbuild.googleapis.com
 
-create-service-account:
+create-function-service-account:
 	gcloud iam service-accounts create $(SERVICE_FUNC_ACCOUNT_NAME) \
 		--project $(GCP_PROJECT) \
 		--display-name $(SERVICE_FUNC_ACCOUNT_DISPNAME)
@@ -56,14 +58,18 @@ create-service-account:
 		--role=roles/compute.instanceAdmin.v1
 	gcloud projects add-iam-policy-binding $(GCP_PROJECT) \
 		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
-		--role=roles/secretmanager.secretAccessor
-	gcloud projects add-iam-policy-binding $(GCP_PROJECT) \
+		--role=roles/iam.serviceAccountUser
+
+delete-function-service-account:
+	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
+		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
+		--role=roles/compute.instanceAdmin.v1
+	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
 		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
 		--role=roles/iam.serviceAccountUser
-	gcloud projects add-iam-policy-binding $(GCP_PROJECT) \
-		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
-		--role=roles/logging.logWriter
+	gcloud --quiet iam service-accounts delete $(SERVICE_FUNC_ACCOUNT_EMAIL) --project $(GCP_PROJECT)
 
+create-compute-service-account:
 	gcloud iam service-accounts create $(SERVICE_VM_ACCOUNT_NAME) \
 		--project $(GCP_PROJECT) \
 		--display-name $(SERVICE_VM_ACCOUNT_DISPNAME)
@@ -77,21 +83,7 @@ create-service-account:
 		--member=serviceAccount:$(SERVICE_VM_ACCOUNT_EMAIL) \
 		--role=roles/logging.logWriter
 
-delete-service-account:
-	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
-		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
-		--role=roles/compute.instanceAdmin.v1
-	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
-		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
-		--role=roles/secretmanager.secretAccessor
-	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
-		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
-		--role=roles/iam.serviceAccountUser
-	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
-		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
-		--role=roles/logging.logWriter
-	gcloud --quiet iam service-accounts delete $(SERVICE_FUNC_ACCOUNT_EMAIL) --project $(GCP_PROJECT)
-
+delete-compute-service-account:
 	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
 		--member=serviceAccount:$(SERVICE_VM_ACCOUNT_EMAIL) \
 		--role=roles/compute.instanceAdmin.v1
@@ -168,7 +160,8 @@ delete-force-deleting-scheduler:
 	add-team list-teams delete-team \
 	clean \
 	enable-api \
-	create-service-account delete-service-account \
+	create-function-service-account delete-function-service-account \
+	create-compute-service-account delete-compute-service-account \
 	deploy-function delete-function \
 	create-creating-scheduler delete-creating-scheduler \
 	create-deleting-scheduler delete-deleting-scheduler \

--- a/Makefile.dctest
+++ b/Makefile.dctest
@@ -5,8 +5,14 @@ TEAM_NAME ?=
 INSTANCE_NUM ?=
 LOG_LEVEL ?= info
 
-SERVICE_ACCOUNT_NAME := auto-dctest
-SERVICE_ACCOUNT_EMAIL := $(SERVICE_ACCOUNT_NAME)@$(GCP_PROJECT).iam.gserviceaccount.com
+SERVICE_FUNC_ACCOUNT_NAME := auto-dctest-function
+SERVICE_FUNC_ACCOUNT_EMAIL := $(SERVICE_FUNC_ACCOUNT_NAME)@$(GCP_PROJECT).iam.gserviceaccount.com
+SERVICE_FUNC_ACCOUNT_DISPNAME := "VM instance create/delete function"
+
+SERVICE_VM_ACCOUNT_NAME := auto-dctest-vminstance
+SERVICE_VM_ACCOUNT_EMAIL := $(SERVICE_VM_ACCOUNT_NAME)@$(GCP_PROJECT).iam.gserviceaccount.com
+SERVICE_VM_ACCOUNT_DISPNAME := "VM instance itself to bootstrap neco/neco-apps"
+
 TOPIC_NAME := auto-dctest-events
 FUNCTION_NAME := auto-dctest
 CREATING_SCHEDULER_PREFIX := create-dctest
@@ -42,36 +48,54 @@ enable-api:
 	gcloud services enable --project $(GCP_PROJECT) cloudbuild.googleapis.com
 
 create-service-account:
-	gcloud iam service-accounts create $(SERVICE_ACCOUNT_NAME) \
+	gcloud iam service-accounts create $(SERVICE_FUNC_ACCOUNT_NAME) \
 		--project $(GCP_PROJECT) \
-		--display-name $(SERVICE_ACCOUNT_NAME)
+		--display-name $(SERVICE_FUNC_ACCOUNT_DISPNAME)
 	gcloud projects add-iam-policy-binding $(GCP_PROJECT) \
-		--member=serviceAccount:$(SERVICE_ACCOUNT_EMAIL) \
+		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
 		--role=roles/compute.instanceAdmin.v1
 	gcloud projects add-iam-policy-binding $(GCP_PROJECT) \
-		--member=serviceAccount:$(SERVICE_ACCOUNT_EMAIL) \
+		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
 		--role=roles/secretmanager.secretAccessor
 	gcloud projects add-iam-policy-binding $(GCP_PROJECT) \
-		--member=serviceAccount:$(SERVICE_ACCOUNT_EMAIL) \
+		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
 		--role=roles/iam.serviceAccountUser
 	gcloud projects add-iam-policy-binding $(GCP_PROJECT) \
-		--member=serviceAccount:$(SERVICE_ACCOUNT_EMAIL) \
+		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
+		--role=roles/logging.logWriter
+
+	gcloud iam service-accounts create $(SERVICE_VM_ACCOUNT_NAME) \
+		--project $(GCP_PROJECT) \
+		--display-name $(SERVICE_VM_ACCOUNT_DISPNAME)
+	gcloud projects add-iam-policy-binding $(GCP_PROJECT) \
+		--member=serviceAccount:$(SERVICE_VM_ACCOUNT_EMAIL) \
+		--role=roles/secretmanager.secretAccessor
+	gcloud projects add-iam-policy-binding $(GCP_PROJECT) \
+		--member=serviceAccount:$(SERVICE_VM_ACCOUNT_EMAIL) \
 		--role=roles/logging.logWriter
 
 delete-service-account:
 	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
-		--member=serviceAccount:$(SERVICE_ACCOUNT_EMAIL) \
+		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
 		--role=roles/compute.instanceAdmin.v1
 	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
-		--member=serviceAccount:$(SERVICE_ACCOUNT_EMAIL) \
+		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
 		--role=roles/secretmanager.secretAccessor
 	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
-		--member=serviceAccount:$(SERVICE_ACCOUNT_EMAIL) \
+		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
 		--role=roles/iam.serviceAccountUser
 	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
-		--member=serviceAccount:$(SERVICE_ACCOUNT_EMAIL) \
+		--member=serviceAccount:$(SERVICE_FUNC_ACCOUNT_EMAIL) \
 		--role=roles/logging.logWriter
-	gcloud --quiet iam service-accounts delete $(SERVICE_ACCOUNT_EMAIL) --project $(GCP_PROJECT)
+	gcloud --quiet iam service-accounts delete $(SERVICE_FUNC_ACCOUNT_EMAIL) --project $(GCP_PROJECT)
+
+	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
+		--member=serviceAccount:$(SERVICE_VM_ACCOUNT_EMAIL) \
+		--role=roles/secretmanager.secretAccessor
+	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
+		--member=serviceAccount:$(SERVICE_VM_ACCOUNT_EMAIL) \
+		--role=roles/logging.logWriter
+	gcloud --quiet iam service-accounts delete $(SERVICE_VM_ACCOUNT_EMAIL) --project $(GCP_PROJECT)
 
 deploy-function:
 	gcloud --quiet functions deploy $(FUNCTION_NAME) \
@@ -83,7 +107,7 @@ deploy-function:
 		--set-env-vars GCP_PROJECT=$(GCP_PROJECT),CYBOZU_LOG_LEVEL=$(LOG_LEVEL) \
 		--memory 128MB \
 		--timeout 300s \
-		--service-account=$(SERVICE_ACCOUNT_EMAIL)
+		--service-account=$(SERVICE_FUNC_ACCOUNT_EMAIL)
 
 delete-function:
 	gcloud --quiet functions delete $(FUNCTION_NAME) --project $(GCP_PROJECT) --region $(REGION)

--- a/Makefile.dctest
+++ b/Makefile.dctest
@@ -69,6 +69,9 @@ create-service-account:
 		--display-name $(SERVICE_VM_ACCOUNT_DISPNAME)
 	gcloud projects add-iam-policy-binding $(GCP_PROJECT) \
 		--member=serviceAccount:$(SERVICE_VM_ACCOUNT_EMAIL) \
+		--role=roles/compute.instanceAdmin.v1
+	gcloud projects add-iam-policy-binding $(GCP_PROJECT) \
+		--member=serviceAccount:$(SERVICE_VM_ACCOUNT_EMAIL) \
 		--role=roles/secretmanager.secretAccessor
 	gcloud projects add-iam-policy-binding $(GCP_PROJECT) \
 		--member=serviceAccount:$(SERVICE_VM_ACCOUNT_EMAIL) \
@@ -89,6 +92,9 @@ delete-service-account:
 		--role=roles/logging.logWriter
 	gcloud --quiet iam service-accounts delete $(SERVICE_FUNC_ACCOUNT_EMAIL) --project $(GCP_PROJECT)
 
+	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
+		--member=serviceAccount:$(SERVICE_VM_ACCOUNT_EMAIL) \
+		--role=roles/compute.instanceAdmin.v1
 	gcloud --quiet projects remove-iam-policy-binding $(GCP_PROJECT) \
 		--member=serviceAccount:$(SERVICE_VM_ACCOUNT_EMAIL) \
 		--role=roles/secretmanager.secretAccessor

--- a/cmd/necogcp/cmd/necotest.go
+++ b/cmd/necogcp/cmd/necotest.go
@@ -4,10 +4,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	projectID string
-	zone      string
-)
+const zone = "asia-northeast1-c"
+
+var projectID string
 
 // necotestCmd is the root subcommand of "necogcp neco-test".
 var necotestCmd = &cobra.Command{
@@ -18,6 +17,5 @@ var necotestCmd = &cobra.Command{
 
 func init() {
 	necotestCmd.PersistentFlags().StringVarP(&projectID, "project-id", "p", "neco-test", "Project ID for GCP")
-	necotestCmd.PersistentFlags().StringVarP(&zone, "zone", "z", "asia-northeast1-c", "Zone name for GCP")
 	rootCmd.AddCommand(necotestCmd)
 }

--- a/cmd/necogcp/cmd/necotest.go
+++ b/cmd/necogcp/cmd/necotest.go
@@ -4,6 +4,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	projectID string
+	zone      string
+)
+
 // necotestCmd is the root subcommand of "necogcp neco-test".
 var necotestCmd = &cobra.Command{
 	Use:   "neco-test",
@@ -12,5 +17,7 @@ var necotestCmd = &cobra.Command{
 }
 
 func init() {
+	necotestCmd.PersistentFlags().StringVarP(&projectID, "project-id", "p", "neco-test", "Project ID for GCP")
+	necotestCmd.PersistentFlags().StringVarP(&zone, "zone", "z", "asia-northeast1-c", "Zone name for GCP")
 	rootCmd.AddCommand(necotestCmd)
 }

--- a/cmd/necogcp/cmd/necotest_createimage.go
+++ b/cmd/necogcp/cmd/necotest_createimage.go
@@ -55,7 +55,5 @@ var necotestCreateImageCmd = &cobra.Command{
 }
 
 func init() {
-	necotestCreateImageCmd.Flags().StringVarP(&projectID, "project-id", "p", "neco-test", "Project ID for GCP")
-	necotestCreateImageCmd.Flags().StringVarP(&zone, "zone", "z", "asia-northeast2-c", "Zone name for GCP")
 	necotestCmd.AddCommand(necotestCreateImageCmd)
 }

--- a/cmd/necogcp/cmd/necotest_createimage.go
+++ b/cmd/necogcp/cmd/necotest_createimage.go
@@ -55,7 +55,7 @@ var necotestCreateImageCmd = &cobra.Command{
 }
 
 func init() {
-	necotestCreateImageCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID for GCP")
+	necotestCreateImageCmd.Flags().StringVarP(&projectID, "project-id", "p", "neco-test", "Project ID for GCP")
 	necotestCreateImageCmd.Flags().StringVarP(&zone, "zone", "z", "asia-northeast2-c", "Zone name for GCP")
 	necotestCmd.AddCommand(necotestCreateImageCmd)
 }

--- a/cmd/necogcp/cmd/necotest_createinstance.go
+++ b/cmd/necogcp/cmd/necotest_createinstance.go
@@ -13,12 +13,10 @@ import (
 )
 
 var (
-	projectID      string
-	zone           string
-	machineType    string
-	instanceName   string
-	necoBranch     string
-	necoAppsBranch string
+	machineType        string
+	createInstanceName string
+	necoBranch         string
+	necoAppsBranch     string
 )
 
 var necotestCreateInstanceCmd = &cobra.Command{
@@ -27,7 +25,7 @@ var necotestCreateInstanceCmd = &cobra.Command{
 	Long:  `Create dctest env for neco (and neco-apps).`,
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(instanceName) == 0 {
+		if len(createInstanceName) == 0 {
 			log.ErrorExit(errors.New("instance name is required"))
 		}
 		if len(projectID) == 0 {
@@ -63,14 +61,14 @@ var necotestCreateInstanceCmd = &cobra.Command{
 			log.Info("start creating instance", map[string]interface{}{
 				"project":        projectID,
 				"zone":           zone,
-				"name":           instanceName,
+				"name":           createInstanceName,
 				"serviceaccount": sa,
 				"machinetype":    machineType,
 				"necobranch":     necoBranch,
 				"necoappsbranch": necoAppsBranch,
 			})
 			return cc.Create(
-				instanceName,
+				createInstanceName,
 				sa,
 				machineType,
 				necogcp.MakeVMXEnabledImageURL(projectID),
@@ -87,10 +85,8 @@ var necotestCreateInstanceCmd = &cobra.Command{
 }
 
 func init() {
-	necotestCreateInstanceCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID for GCP")
-	necotestCreateInstanceCmd.Flags().StringVarP(&zone, "zone", "z", "asia-northeast1-c", "Zone name for GCP")
 	necotestCreateInstanceCmd.Flags().StringVarP(&machineType, "machine-type", "t", "n1-standard-32", "Machine type")
-	necotestCreateInstanceCmd.Flags().StringVarP(&instanceName, "instance-name", "n", "", "Instance name")
+	necotestCreateInstanceCmd.Flags().StringVarP(&createInstanceName, "instance-name", "n", "", "Instance name")
 	necotestCreateInstanceCmd.Flags().StringVar(&necoBranch, "neco-branch", "release", "Branch of cybozu-go/neco to run")
 	necotestCreateInstanceCmd.Flags().StringVar(&necoAppsBranch, "neco-apps-branch", "release", "Branch of cybozu-go/neco-apps to run")
 	necotestCmd.AddCommand(necotestCreateInstanceCmd)

--- a/cmd/necogcp/cmd/necotest_deleteinstance.go
+++ b/cmd/necogcp/cmd/necotest_deleteinstance.go
@@ -10,13 +10,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var deleteInstanceName string
+
 var necotestDeleteInstanceCmd = &cobra.Command{
 	Use:   "delete-instance",
 	Short: "Delete instance",
 	Long:  `Delete instance.`,
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(instanceName) == 0 {
+		if len(deleteInstanceName) == 0 {
 			log.ErrorExit(errors.New("instance name is required"))
 		}
 		if len(projectID) == 0 {
@@ -33,9 +35,9 @@ var necotestDeleteInstanceCmd = &cobra.Command{
 			log.Info("start deleting instance", map[string]interface{}{
 				"project": projectID,
 				"zone":    zone,
-				"name":    instanceName,
+				"name":    deleteInstanceName,
 			})
-			return cc.Delete(instanceName)
+			return cc.Delete(deleteInstanceName)
 		})
 
 		well.Stop()
@@ -47,8 +49,6 @@ var necotestDeleteInstanceCmd = &cobra.Command{
 }
 
 func init() {
-	necotestDeleteInstanceCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID for GCP")
-	necotestDeleteInstanceCmd.Flags().StringVarP(&zone, "zone", "z", "asia-northeast1-c", "Zone name for GCP")
-	necotestDeleteInstanceCmd.Flags().StringVarP(&instanceName, "instance-name", "n", "", "Instance name")
+	necotestDeleteInstanceCmd.Flags().StringVarP(&deleteInstanceName, "instance-name", "n", "", "Instance name")
 	necotestCmd.AddCommand(necotestDeleteInstanceCmd)
 }

--- a/cmd/necogcp/cmd/necotest_extend.go
+++ b/cmd/necogcp/cmd/necotest_extend.go
@@ -34,7 +34,5 @@ var necotestExtendCmd = &cobra.Command{
 }
 
 func init() {
-	necotestDeleteImageCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID for GCP")
-	necotestDeleteImageCmd.Flags().StringVarP(&zone, "zone", "z", "asia-northeast2-c", "Zone name for GCP")
 	necotestCmd.AddCommand(necotestExtendCmd)
 }

--- a/cmd/necogcp/cmd/necotest_listinstances.go
+++ b/cmd/necogcp/cmd/necotest_listinstances.go
@@ -61,8 +61,6 @@ var necotestListInstancesCmd = &cobra.Command{
 }
 
 func init() {
-	necotestListInstancesCmd.Flags().StringVarP(&projectID, "project-id", "p", "", "Project ID for GCP")
-	necotestListInstancesCmd.Flags().StringVarP(&zone, "zone", "z", "asia-northeast1-c", "Zone name for GCP")
 	necotestListInstancesCmd.Flags().StringVarP(&filter, "filter", "f", "", "Filter string")
 	necotestCmd.AddCommand(necotestListInstancesCmd)
 }

--- a/gcp/compute_cli.go
+++ b/gcp/compute_cli.go
@@ -50,7 +50,7 @@ type ComputeCLIClient struct {
 // NewComputeCLIClient returns ComputeClient
 func NewComputeCLIClient(cfg *Config, instance string) *ComputeCLIClient {
 	user := os.Getenv("USER")
-	if cfg.Common.Project == "neco-test" {
+	if cfg.Common.Project == "neco-test" || cfg.Common.Project == "neco-dev" {
 		user = "cybozu"
 	}
 

--- a/gcp/vmxenabled.go
+++ b/gcp/vmxenabled.go
@@ -122,7 +122,7 @@ func SetupVMXEnabled(ctx context.Context, project string, option []string) error
 		return err
 	}
 
-	if project == "neco-test" {
+	if project == "neco-test" || project == "neco-dev" {
 		err = downloadAssets(client)
 		if err != nil {
 			return err

--- a/neco.go
+++ b/neco.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	necoAppsAccountSecretName    = "cloud-dns-admin-account"
-	autoDCTestServiceAccountName = "auto-dctest"
+	autoDCTestServiceAccountName = "auto-dctest-vminstance"
 	slackNotifierConfigName      = "slack-notifier-config"
 )
 


### PR DESCRIPTION
This PR includes some fix for the initial PR https://github.com/cybozu-go/neco-gcp/pull/2 .
- Update procedure for setting quota
- Fix `necogcp neco-test create-image` to update vmx-enabled image on neco-test and neco-dev
- Seperate the service account of the Cloud Function `auto-dctest` to have minimal roles.

Signed-off-by: H.Muraoka <hiroshi-muraoka@cybozu.co.jp>