### PR TITLE
Do not install unnecessary packages

### DIFF
--- a/gcp/artifacts.go
+++ b/gcp/artifacts.go
@@ -31,11 +31,7 @@ var artifacts = artifactSet{
 		"unzip",
 		"skopeo",
 		// required by building neco
-		"libdevmapper-dev",
-		"libgpgme-dev",
-		"libostree-dev",
 		"fakeroot",
-		"btrfs-tools",
 		// docker CE
 		"docker-ce",
 		"docker-ce-cli",


### PR DESCRIPTION
With https://github.com/cybozu-go/neco/issues/1387 , some of the pre-installed libraries are no longer used.

I have run neco/dctest successfully on the image created with this change.