### PR TITLE
modify secret update procedure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 statik.go
+slack-notifier-config.yaml

--- a/Makefile.slack
+++ b/Makefile.slack
@@ -10,6 +10,8 @@ TOPIC_NAME := slack-notifier-events
 FUNCTION_NAME := slack-notifier
 SINK_NAME := auto-dctest-alerts
 
+SECRET_NAME := slack-notifier-config
+
 setup:
 	sudo apt-get update
 	sudo apt-get install -y --no-install-recommends jq
@@ -73,6 +75,12 @@ create-logging-sink:
 delete-logging-sink:
 	gcloud --quiet logging sinks delete $(SINK_NAME) --project $(GCP_PROJECT)
 
+create-slack-notifier-config: slack-notifier-config.yaml
+	gcloud secrets create ${SECRET_NAME} --data-file=$< --project $(GCP_PROJECT)
+
+update-slack-notifier-config: slack-notifier-config.yaml
+	gcloud secrets versions add ${SECRET_NAME} --data-file=$< --project $(GCP_PROJECT)
+
 .PHONY: \
 	setup \
 	init \
@@ -80,4 +88,5 @@ delete-logging-sink:
 	enable-api \
 	create-service-account delete-service-account \
 	deploy-function delete-function \
-	create-logging-sink delete-logging-sink
+	create-logging-sink delete-logging-sink \
+	create-slack-notifier-config update-slack-notifier-config

--- a/docs/auto-dctest.md
+++ b/docs/auto-dctest.md
@@ -157,13 +157,20 @@ severity: # See https://api.slack.com/reference/messaging/attachments#fields
 rules:
   - name: team1-rule
     regex: team1-[0-9]+
+    excludeRegex: 'team1-0'
     targetTeams:
       - team1
 ```
 
-With the above setting, the notifications for `team1`'s instance with postfix `-[0-9]+` will be sent to `team1`'s Slack webhook.
+With the above setting, the notifications for `team1`'s instance with postfix `-[0-9]+` except for `team1-0` will be sent to `team1`'s Slack webhook.
 
 This YAML file must be uploaded to Secret Manager with the specific name `slack-notifier-config`.
+
+You should save the YAML file as `slack-notifier-config.yaml` and run the following commands.
+```
+export GCP_PROJECT=<project>
+make create-slack-notifier-config -f Makefile.slack
+```
 
 ### Manual management with `necogcp` command
 
@@ -207,8 +214,13 @@ so an administrator should modify it periodically.
 
 #### Team management
 
-To add a team, an administrator should run `make -f Makefile.dctest add-team` and
-modify Slack settings and upload it to Secret Manager.
+To add a team, an administrator should run as follows
+```
+export GCP_PROJECT=<project>
+make -f Makefile.dctest add-team TEAM_NAME=<team name> INSTANCE_NUM=<max instance number>
+# create slack-notifier-config.yaml
+make update-slack-notifier-config -f Makefile.slack
+```
 
 ### Development
 


### PR DESCRIPTION
Currently, to update `slack-notifier-config` secret, it is required to updater from Web UI.
This PR enables us to update the secret by make command.

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>