### PR TITLE
create scheduled instances by every 30 mins if they do not exist

### DIFF
--- a/Makefile.dctest
+++ b/Makefile.dctest
@@ -118,7 +118,7 @@ create-creating-scheduler:
 	fi
 	gcloud scheduler jobs create pubsub $(CREATING_SCHEDULER_NAME) \
 		--project $(GCP_PROJECT) \
-		--schedule '0 9 * * 1-5' \
+		--schedule '*/30 9-19 * * 1-5' \
 		--topic $(TOPIC_NAME) \
 		--message-body '{"mode":"create", "namePrefix":"$(TEAM_NAME)", "num":$(INSTANCE_NUM)}' \
 		--time-zone 'Asia/Tokyo' \

--- a/docs/auto-dctest.md
+++ b/docs/auto-dctest.md
@@ -21,7 +21,7 @@ This document describes the system which bootstraps [Neco](https://github.com/cy
 This system consists of the following two types of components:
 
 - `auto-dctest`: create/delete VM instances
-  - Cloud Scheduler(to create VM): triggered at 9:00AM
+  - Cloud Scheduler(to create VM): triggered every 30 minutes between 9:00AM and 8:00PM
   - Cloud Scheduler(to delete VM): triggered at 8:00PM
   - Cloud Scheduler(to force-delete VM): triggered at 11:00PM
   - Cloud Pub/Sub: messaging queue to accept messages from Cloud Scheduler


### PR DESCRIPTION
Auto scheduled dctest instances for tenant teams might be deleted due to the instability of CI.
In that case, the instances should be automatically recreated.

In this PR, run the scheduler every 30 mins and recreate the instances if not exist.

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>