### PR TITLE
Update GCP artifacts

### DIFF
--- a/gcp/artifacts.go
+++ b/gcp/artifacts.go
@@ -1,10 +1,10 @@
 package gcp
 
 var artifacts = artifactSet{
-	goVersion:        "1.16.2",
-	etcdVersion:      "3.3.19",
+	goVersion:        "1.16.6",
+	etcdVersion:      "3.4.16",
 	placematVersion:  "2.0.5",
-	coreOSVersion:    "2605.5.0",
+	coreOSVersion:    "2765.2.6",
 	ctVersion:        "0.6.1",
 	baseImage:        "ubuntu-2004-focal-v20210510",
 	baseImageProject: "ubuntu-os-cloud",


### PR DESCRIPTION
"ctVersion," the version of [Container Linux Config Transpiler](https://github.com/coreos/container-linux-config-transpiler),
is left unchanged because we have no trouble with the current version.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>