### PR TITLE
Remove syscall package

### DIFF
--- a/gcp/hostvm.go
+++ b/gcp/hostvm.go
@@ -148,7 +148,7 @@ func mountHomeDisk(ctx context.Context) error {
 	}
 
 	for {
-		err = well.CommandContext(ctx, "/bin/mount", "-t", homeFSType, "-o", "relatime", homeDisk, homeMountPoint).Run()
+		err = well.CommandContext(ctx, "/bin/mount", "-t", homeFSType, homeDisk, homeMountPoint).Run()
 		if err == nil {
 			break
 		}
@@ -173,7 +173,7 @@ func formatHomeDisk(ctx context.Context) error {
 	}
 
 	for {
-		err = well.CommandContext(ctx, "/bin/mount", "-t", homeFSType, "-o", "relatime", homeDisk, "/mnt").Run()
+		err = well.CommandContext(ctx, "/bin/mount", "-t", homeFSType, homeDisk, "/mnt").Run()
 		if err == nil {
 			break
 		}
@@ -213,7 +213,7 @@ func setupLocalSSD(ctx context.Context) error {
 	}
 
 	for {
-		err = well.CommandContext(ctx, "/bin/mount", "-t", localSSDFSType, "-o", "relatime", localSSDDisk, localSSDMountPoint).Run()
+		err = well.CommandContext(ctx, "/bin/mount", "-t", localSSDFSType, localSSDDisk, localSSDMountPoint).Run()
 		if err == nil {
 			break
 		}


### PR DESCRIPTION
`negogcp` cannot be built for Mac, because of using the `syscall` package.
This PR stops using the `syscall` package and uses the `mount`/`umount` commands.

NOTE:
When using the mount command, the default seems to be `relatime`, so I removed the `relatime` option.

```
$ GOOS=darwin GOARCH=amd64 make build-necogcp
mkdir -p build
GOOS=darwin GOARCH=amd64 go build -o ./build/necogcp ./cmd/necogcp
# github.com/cybozu-go/neco-gcp/gcp
gcp/hostvm.go:152:10: undefined: syscall.Mount
gcp/hostvm.go:152:62: undefined: syscall.MS_RELATIME
gcp/hostvm.go:177:9: undefined: syscall.Mount
gcp/hostvm.go:177:53: undefined: syscall.MS_RELATIME
gcp/hostvm.go:193:34: undefined: syscall.MNT_FORCE
gcp/hostvm.go:217:10: undefined: syscall.Mount
gcp/hostvm.go:217:74: undefined: syscall.MS_RELATIME
make: *** [Makefile:24: build-necogcp] Error 2
```

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>