### PR TITLE
fix command line parameters when resizing home directory

### DIFF
--- a/pkg/gcp/compute_cli.go
+++ b/pkg/gcp/compute_cli.go
@@ -276,7 +276,7 @@ func (cc *ComputeCLIClient) ResizeHomeDisk(ctx context.Context) error {
 	}
 
 	gcmdResize := cc.gCloudComputeDisks()
-	gcmdResize = append(gcmdResize, "resize", "home", "--size", configSize)
+	gcmdResize = append(gcmdResize, "resize", "home", "--size", configSize, "--zone", cc.cfg.Common.Zone)
 	c = well.CommandContext(ctx, gcmdResize[0], gcmdResize[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout


### PR DESCRIPTION
Resizing the home directory fails due to insufficient parameters provided to the `gcloud` command: 

```
ERROR: (gcloud.compute.disks.resize) Underspecified resource [home]. Specify one of the [--region, --zone] flags.
```

Repro steps:
- with an existing necogcp instance deployed, edit `.necogcp.yml` increasing the `home-disk-sizeGB` (ex: 20GB→80GB)
- run `necogcp delete-instance`, then `necogcp create-instance`
- the above error should occur