### PR TITLE
Fix redundant function names

### DIFF
--- a/cmd/dev/cmd/create.go
+++ b/cmd/dev/cmd/create.go
@@ -53,7 +53,7 @@ Please push "Run Now" button on Cloud Scheduler when running dctest`,
 				"instancenameprefix": instanceNamePrefix,
 				"instancesnum":       instancesNum,
 			})
-			runner := autodctest.NewAutoDCTestRunner(cc)
+			runner := autodctest.NewRunner(cc)
 			return runner.CreateInstancesIfNotExist(
 				ctx,
 				instanceNamePrefix,

--- a/cmd/dev/cmd/delete.go
+++ b/cmd/dev/cmd/delete.go
@@ -37,7 +37,7 @@ Please DO NOT use this command except for the purpose.
 				"project": projectID,
 				"zone":    zone,
 			})
-			runner := autodctest.NewAutoDCTestRunner(cc)
+			runner := autodctest.NewRunner(cc)
 			return runner.DeleteFilteredInstances(ctx, "")
 		})
 

--- a/cmd/necogcp/cmd/necotest_createinstance.go
+++ b/cmd/necogcp/cmd/necotest_createinstance.go
@@ -38,7 +38,7 @@ var necotestCreateInstanceCmd = &cobra.Command{
 				"serviceaccount": serviceAccountEmail,
 			})
 		}
-		builder := autodctest.NewNecoStartupScriptBuilder().WithFluentd()
+		builder := autodctest.NewStartupScriptBuilder().WithFluentd()
 		if len(necoBranch) > 0 {
 			log.Info("run neco", map[string]interface{}{
 				"branch": necoBranch,

--- a/pkg/autodctest/entrypoint.go
+++ b/pkg/autodctest/entrypoint.go
@@ -25,8 +25,8 @@ const (
 	projectIDEnvName = "GCP_PROJECT"
 )
 
-// AutoDCTestMessageBody is body of Pub/Sub message.
-type AutoDCTestMessageBody struct {
+// messageBody is body of Pub/Sub message.
+type messageBody struct {
 	Mode               string `json:"mode"`
 	InstanceNamePrefix string `json:"namePrefix"`
 	InstancesNum       int    `json:"num"`
@@ -38,7 +38,7 @@ func EntryPoint(ctx context.Context, m *pubsub.Message, machineType, zone string
 	log.Debug("msg body", map[string]interface{}{
 		"data": string(m.Data),
 	})
-	var b AutoDCTestMessageBody
+	var b messageBody
 	err := json.Unmarshal(m.Data, &b)
 	if err != nil {
 		log.Error("failed to unmarshal json", map[string]interface{}{
@@ -68,7 +68,7 @@ func EntryPoint(ctx context.Context, m *pubsub.Message, machineType, zone string
 		})
 		return err
 	}
-	runner := NewAutoDCTestRunner(client)
+	runner := NewRunner(client)
 
 	switch b.Mode {
 	case createInstancesMode:
@@ -90,7 +90,7 @@ func EntryPoint(ctx context.Context, m *pubsub.Message, machineType, zone string
 			return nil
 		}
 
-		builder, err := NewNecoStartupScriptBuilder().
+		builder, err := NewStartupScriptBuilder().
 			WithFluentd().
 			WithNeco(necoBranch).
 			WithNecoApps(necoAppsBranch)

--- a/pkg/autodctest/runner.go
+++ b/pkg/autodctest/runner.go
@@ -9,22 +9,22 @@ import (
 	"github.com/cybozu-go/well"
 )
 
-// AutoDCTestRunner runs dctest environments on GCP instances
-type AutoDCTestRunner struct {
+// Runner runs dctest environments on GCP instances
+type Runner struct {
 	compute *gcp.ComputeClient
 }
 
-// NewAutoDCTestRunner creates Runner
-func NewAutoDCTestRunner(computeClient *gcp.ComputeClient) *AutoDCTestRunner {
-	return &AutoDCTestRunner{compute: computeClient}
+// NewRunner creates Runner
+func NewRunner(computeClient *gcp.ComputeClient) *Runner {
+	return &Runner{compute: computeClient}
 }
 
-func (r AutoDCTestRunner) makeInstanceName(prefix string, index int) string {
+func (r Runner) makeInstanceName(prefix string, index int) string {
 	return fmt.Sprintf("%s-%d", prefix, index)
 }
 
 // CreateInstancesIfNotExist lists instances not existing and create them
-func (r AutoDCTestRunner) CreateInstancesIfNotExist(
+func (r Runner) CreateInstancesIfNotExist(
 	ctx context.Context,
 	instanceNamePrefix string,
 	instancesNum int,
@@ -84,7 +84,7 @@ func (r AutoDCTestRunner) CreateInstancesIfNotExist(
 }
 
 // DeleteFilteredInstances deletes instances which match the given filter
-func (r AutoDCTestRunner) DeleteFilteredInstances(ctx context.Context, filter string) error {
+func (r Runner) DeleteFilteredInstances(ctx context.Context, filter string) error {
 	set, err := r.compute.GetNameSet(filter)
 	if err != nil {
 		log.Error("failed to get instances list", map[string]interface{}{

--- a/pkg/autodctest/startupscript.go
+++ b/pkg/autodctest/startupscript.go
@@ -18,32 +18,32 @@ func MakeNecoDevServiceAccountEmail(projectID string) string {
 	return fmt.Sprintf("%s@%s.iam.gserviceaccount.com", autoDCTestServiceAccountName, projectID)
 }
 
-// NecoStartupScriptBuilder creates startup-script builder to run dctest
-type NecoStartupScriptBuilder struct {
+// StartupScriptBuilder creates startup-script builder to run dctest
+type StartupScriptBuilder struct {
 	withFluentd    bool
 	necoBranch     string
 	necoAppsBranch string
 }
 
-// NewNecoStartupScriptBuilder creates NecoStartupScriptBuilder
-func NewNecoStartupScriptBuilder() *NecoStartupScriptBuilder {
-	return &NecoStartupScriptBuilder{}
+// NewStartupScriptBuilder creates NecoStartupScriptBuilder
+func NewStartupScriptBuilder() *StartupScriptBuilder {
+	return &StartupScriptBuilder{}
 }
 
 // WithFluentd enables fluentd logging
-func (b *NecoStartupScriptBuilder) WithFluentd() *NecoStartupScriptBuilder {
+func (b *StartupScriptBuilder) WithFluentd() *StartupScriptBuilder {
 	b.withFluentd = true
 	return b
 }
 
 // WithNeco sets branch name to run neco
-func (b *NecoStartupScriptBuilder) WithNeco(branch string) *NecoStartupScriptBuilder {
+func (b *StartupScriptBuilder) WithNeco(branch string) *StartupScriptBuilder {
 	b.necoBranch = branch
 	return b
 }
 
 // WithNecoApps sets branch name to run neco-apps
-func (b *NecoStartupScriptBuilder) WithNecoApps(branch string) (*NecoStartupScriptBuilder, error) {
+func (b *StartupScriptBuilder) WithNecoApps(branch string) (*StartupScriptBuilder, error) {
 	if len(b.necoBranch) == 0 {
 		return nil, errors.New("please specify neco branch to run neco-apps")
 	}
@@ -52,7 +52,7 @@ func (b *NecoStartupScriptBuilder) WithNecoApps(branch string) (*NecoStartupScri
 }
 
 // Build  builds startup script
-func (b *NecoStartupScriptBuilder) Build() string {
+func (b *StartupScriptBuilder) Build() string {
 	s := `#! /bin/sh
 
 echo "starting auto dctest..."

--- a/pkg/autodctest/startupscript_test.go
+++ b/pkg/autodctest/startupscript_test.go
@@ -6,12 +6,12 @@ import (
 )
 
 func TestNecoStartupScriptBuilder(t *testing.T) {
-	_, err := NewNecoStartupScriptBuilder().WithNecoApps("this-is-neco-apps")
+	_, err := NewStartupScriptBuilder().WithNecoApps("this-is-neco-apps")
 	if err == nil {
 		t.Errorf("should fail when neco-apps is enabled without neco")
 	}
 
-	builder, err := NewNecoStartupScriptBuilder().
+	builder, err := NewStartupScriptBuilder().
 		WithFluentd().
 		WithNeco("this-is-neco").
 		WithNecoApps("this-is-neco-apps")

--- a/pkg/slacknotifier/config.go
+++ b/pkg/slacknotifier/config.go
@@ -10,8 +10,8 @@ import (
 // "good" is recognized as red by slack API
 const defaultColor = "good"
 
-// SlackNotifierConfig is a Slack notifier
-type SlackNotifierConfig struct {
+// Config is a Slack notifier
+type Config struct {
 	Teams    map[string]string `yaml:"teams"`
 	Severity []Severity        `yaml:"severity"`
 	Rules    []Rule            `yaml:"rules"`
@@ -31,9 +31,9 @@ type Rule struct {
 	TargetTeams  []string `yaml:"targetTeams"`
 }
 
-// NewSlackNotifierConfig creates new Notifier from config YAML
-func NewSlackNotifierConfig(configYAML []byte) (*SlackNotifierConfig, error) {
-	var n SlackNotifierConfig
+// NewConfig creates new Notifier from config YAML
+func NewConfig(configYAML []byte) (*Config, error) {
+	var n Config
 	err := yaml.Unmarshal(configYAML, &n)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func NewSlackNotifierConfig(configYAML []byte) (*SlackNotifierConfig, error) {
 }
 
 // FindTeamsByInstanceName returns matched URLs of target teams
-func (c SlackNotifierConfig) FindTeamsByInstanceName(target string) (map[string]struct{}, error) {
+func (c Config) FindTeamsByInstanceName(target string) (map[string]struct{}, error) {
 	teams := make(map[string]struct{})
 	for _, r := range c.Rules {
 		matched, err := regexp.Match(r.Regex, []byte(target))
@@ -70,7 +70,7 @@ func (c SlackNotifierConfig) FindTeamsByInstanceName(target string) (map[string]
 }
 
 // GetWebHookURLsFromTeams returns webhook URLs set from the given teams
-func (c SlackNotifierConfig) GetWebHookURLsFromTeams(teams map[string]struct{}) (map[string]struct{}, error) {
+func (c Config) GetWebHookURLsFromTeams(teams map[string]struct{}) (map[string]struct{}, error) {
 	urls := make(map[string]struct{})
 	for t := range teams {
 		v, ok := c.Teams[t]
@@ -84,7 +84,7 @@ func (c SlackNotifierConfig) GetWebHookURLsFromTeams(teams map[string]struct{}) 
 }
 
 // FindColorByMessage returns color by maching regex with message
-func (c SlackNotifierConfig) FindColorByMessage(message string) (string, error) {
+func (c Config) FindColorByMessage(message string) (string, error) {
 	for _, s := range c.Severity {
 		matched, err := regexp.Match(s.Regex, []byte(message))
 		if err != nil {

--- a/pkg/slacknotifier/config_test.go
+++ b/pkg/slacknotifier/config_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestSlackNotifierConfig(t *testing.T) {
+func TestConfig(t *testing.T) {
 	yaml := `
 teams:
   team1: https://webhook/team1
@@ -40,13 +40,13 @@ rules:
     targetTeams:
       - team5
 `
-	n, err := NewSlackNotifierConfig([]byte(yaml))
+	n, err := NewConfig([]byte(yaml))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	exRegex := "sample5-100"
-	expect := SlackNotifierConfig{
+	expect := Config{
 		Teams: map[string]string{
 			"team1": "https://webhook/team1",
 			"team2": "https://webhook/team2",

--- a/pkg/slacknotifier/entrypoint.go
+++ b/pkg/slacknotifier/entrypoint.go
@@ -59,7 +59,7 @@ func EntryPoint(ctx context.Context, m *pubsub.Message) error {
 		"len": len(result.GetPayload().GetData()),
 	})
 
-	c, err := NewSlackNotifierConfig(result.GetPayload().GetData())
+	c, err := NewConfig(result.GetPayload().GetData())
 	if err != nil {
 		log.Error("failed to read config", map[string]interface{}{
 			log.FnError: err,


### PR DESCRIPTION
Fix the function names that have become redundant due to https://github.com/cybozu-go/neco-gcp/pull/91 and https://github.com/cybozu-go/neco-gcp/pull/84.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>