### PR TITLE
Update base image for VMXEnabled

### DIFF
--- a/config_vmxenabled.go
+++ b/config_vmxenabled.go
@@ -6,7 +6,7 @@ import "github.com/cybozu-go/neco-gcp/pkg/setup"
 // This setting is used by both "necogcp create-image" and "necogcp neco-test create-image".
 const (
 	VMXEnabledBaseImageProject = "ubuntu-os-cloud"
-	VMXEnabledBaseImage        = "ubuntu-2004-focal-v20210908"
+	VMXEnabledBaseImage        = "ubuntu-2004-focal-v20211202"
 )
 
 // The settings of software which installed in the VMXEnabled image.


### PR DESCRIPTION
Update the base image of VMXEnabled to `ubuntu-2004-focal-v20211202`.

The current Ubuntu image is as follows:
```
$ gcloud compute images list --filter 'family:ubuntu'
NAME                                   PROJECT              FAMILY                   DEPRECATED  STATUS
ubuntu-1804-bionic-v20211115           ubuntu-os-cloud      ubuntu-1804-lts                      READY
ubuntu-pro-1604-xenial-v20210720       ubuntu-os-pro-cloud  ubuntu-pro-1604-lts                  READY
ubuntu-pro-1804-bionic-v20210720       ubuntu-os-pro-cloud  ubuntu-pro-1804-lts                  READY
ubuntu-pro-2004-focal-v20210720        ubuntu-os-pro-cloud  ubuntu-pro-2004-lts                  READY
ubuntu-2004-focal-v20211202            ubuntu-os-cloud      ubuntu-2004-lts                      READY
ubuntu-2104-hirsute-v20211119          ubuntu-os-cloud      ubuntu-2104                          READY
ubuntu-2110-impish-v20211014           ubuntu-os-cloud      ubuntu-2110                          READY
ubuntu-minimal-1604-xenial-v20210430   ubuntu-os-cloud      ubuntu-minimal-1604-lts              READY
ubuntu-minimal-1804-bionic-v20211119   ubuntu-os-cloud      ubuntu-minimal-1804-lts              READY
ubuntu-minimal-2004-focal-v20211203    ubuntu-os-cloud      ubuntu-minimal-2004-lts              READY
ubuntu-minimal-2104-hirsute-v20211119  ubuntu-os-cloud      ubuntu-minimal-2104                  READY
ubuntu-minimal-2110-impish-v20211119   ubuntu-os-cloud      ubuntu-minimal-2110                  READY
```


Signed-off-by: Masayuki Ishii <masa213f@gmail.com>