### PR TITLE
Update GCE base image

### DIFF
--- a/config_vmxenabled.go
+++ b/config_vmxenabled.go
@@ -6,7 +6,7 @@ import "github.com/cybozu-go/neco-gcp/pkg/setup"
 // This setting is used by both "necogcp create-image" and "necogcp neco-test create-image".
 const (
 	VMXEnabledBaseImageProject = "ubuntu-os-cloud"
-	VMXEnabledBaseImage        = "ubuntu-2004-focal-v20211202"
+	VMXEnabledBaseImage        = "ubuntu-2004-focal-v20220308"
 )
 
 // The settings of software which installed in the VMXEnabled image.


### PR DESCRIPTION
Update GCE base image to `ubuntu-2004-focal-v20220308`.

```
$ date
Mon 14 Mar 2022 01:55:00 AM UTC
$ gcloud compute images list --filter 'family:ubuntu'
NAME                                   PROJECT              FAMILY                    DEPRECATED  STATUS
ubuntu-1804-bionic-v20220308           ubuntu-os-cloud      ubuntu-1804-lts                       READY
ubuntu-pro-1604-xenial-v20211213       ubuntu-os-pro-cloud  ubuntu-pro-1604-lts                   READY
ubuntu-pro-1804-bionic-v20220308       ubuntu-os-pro-cloud  ubuntu-pro-1804-lts                   READY
ubuntu-pro-2004-focal-v20220308        ubuntu-os-pro-cloud  ubuntu-pro-2004-lts                   READY
ubuntu-pro-fips-1804-bionic-v20220301  ubuntu-os-pro-cloud  ubuntu-pro-fips-1804-lts              READY
ubuntu-pro-fips-2004-focal-v20220301a  ubuntu-os-pro-cloud  ubuntu-pro-fips-2004-lts              READY
ubuntu-2004-focal-v20220308            ubuntu-os-cloud      ubuntu-2004-lts                       READY
ubuntu-2110-impish-v20220309           ubuntu-os-cloud      ubuntu-2110                           READY
ubuntu-minimal-1804-bionic-v20220308   ubuntu-os-cloud      ubuntu-minimal-1804-lts               READY
ubuntu-minimal-2004-focal-v20220308    ubuntu-os-cloud      ubuntu-minimal-2004-lts               READY
ubuntu-minimal-2110-impish-v20220308   ubuntu-os-cloud      ubuntu-minimal-2110                   READY
```

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>