### PR TITLE
Remove unnecessary environment variable

### DIFF
--- a/.github/workflows/update-functions.yaml
+++ b/.github/workflows/update-functions.yaml
@@ -8,8 +8,6 @@ jobs:
   update-neco-dev:
     name: Update neco-dev project
     runs-on: ubuntu-20.04
-    env:
-      GCP_PROJECT: neco-dev
     steps:
       - uses: actions/checkout@v3
       - uses: google-github-actions/auth@v0.7.0
@@ -28,8 +26,6 @@ jobs:
   update-neco-test:
     name: Update neco-test project
     runs-on: ubuntu-20.04
-    env:
-      GCP_PROJECT: neco-test
     steps:
       - uses: actions/checkout@v3
       - uses: google-github-actions/auth@v0.7.0


### PR DESCRIPTION
The `GCP_PROJECT` environment variable is exported by `google-github-actions/auth`.
So we need not specify it in a workflow.

https://github.com/google-github-actions/auth/tree/v0.7.0#other-inputs
-> Please see the `export_environment_variables` option.

https://github.com/google-github-actions/auth/blob/v0.7.0/action.yml#L61-L83
-> The `export_environment_variables` option is true by default.


NOTE: The current workflow records the following warnings.
https://github.com/cybozu-go/neco-gcp/actions/runs/2180306334

![warning](https://user-images.githubusercontent.com/47380942/163737065-35eb2973-3434-4ccd-9221-068316ef479b.png)


Signed-off-by: Masayuki Ishii <masa213f@gmail.com>