### PR TITLE
Wait snap auto-refresh

### DIFF
--- a/pkg/autodctest/startupscript.go
+++ b/pkg/autodctest/startupscript.go
@@ -57,18 +57,20 @@ func (b *StartupScriptBuilder) Build() string {
 
 echo "starting auto dctest..."
 
+# Wait for auto-refresh to be done
+snap watch --last=auto-refresh
+
 # Set environment variables
 HOME=/root
 GOPATH=${HOME}/go
-GO111MODULE=on
 PATH=${PATH}:/usr/local/go/bin:${GOPATH}/bin
 NECO_DIR=${GOPATH}/src/github.com/cybozu-go/neco
-export HOME GOPATH GO111MODULE PATH NECO_DIR
+export HOME GOPATH PATH NECO_DIR
 
 delete_myself()
 {
 echo "[auto-dctest] Auto dctest failed. Deleting the instance..."
-/snap/bin/gcloud --quiet compute instances delete $NAME --zone=$ZONE
+gcloud --quiet compute instances delete $NAME --zone=$ZONE
 }
 `
 


### PR DESCRIPTION
When a GCP instance is started, the `gcloud` command temporarily disappears by snap's auto-refresh.
And it sometimes causes an error of auto-dctest.

This PR wait for the auto-refresh to prevent errors, when the beggining of the startup-script.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>