### PR TITLE
Use (*http.Transport).Clone() instead of copying http.DefaultTransport manually

### DIFF
--- a/pkg/setup/vmxenabled.go
+++ b/pkg/setup/vmxenabled.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"os"
 	"path"
@@ -72,18 +71,9 @@ func VMXEnabled(ctx context.Context, project string, artifacts *ArtifactSet, opt
 		return err
 	}
 
-	transport := &http.Transport{
-		Proxy: nil,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).DialContext,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.ForceAttemptHTTP2 = false
 
 	client := &http.Client{
 		Transport: transport,


### PR DESCRIPTION
This PR uses a clone of `http.DefaultTransport` instead of copying its values manually.
`Dialer.DualStack` is deprecated, so it is removed from the code.

See: 
- https://github.com/golang/go/blob/release-branch.go1.19/src/net/http/transport.go#L38
- https://github.com/golang/go/blob/release-branch.go1.19/src/net/dial.go#L54
- https://github.com/cybozu/neco-containers/pull/865

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>