### PR TITLE
Add docker buildx package

### DIFF
--- a/config_vmxenabled.go
+++ b/config_vmxenabled.go
@@ -47,6 +47,7 @@ var VMXEnabledArtifacts = setup.ArtifactSet{
 		// docker CE
 		"docker-ce",
 		"docker-ce-cli",
+		"docker-buildx-plugin",
 		"containerd.io",
 	},
 }


### PR DESCRIPTION
Starting with docker v23.0.0 , docker build containers using BuildKit by default.
If BuildKit is not installed, the legacy builder is automatically used.
Since the Legacy builders seems to be deprecated, it is necessary to install buildkit package.
https://docs.docker.com/engine/deprecated/#legacy-builder-fallback

zeroalphat <taichi-takemura@cybozu.co.jp>