### PR TITLE
Fix 128MB to 128MiB

### DIFF
--- a/Makefile.dctest
+++ b/Makefile.dctest
@@ -103,7 +103,7 @@ deploy-function:
 		--runtime go121 \
 		--trigger-topic $(TOPIC_NAME) \
 		--set-env-vars GCP_PROJECT=$(GCP_PROJECT),CYBOZU_LOG_LEVEL=$(LOG_LEVEL) \
-		--memory 128MB \
+		--memory 128MiB \
 		--timeout 300s \
 		--service-account=$(SERVICE_FUNCTION_ACCOUNT_EMAIL)
 

--- a/Makefile.instancedel
+++ b/Makefile.instancedel
@@ -62,7 +62,7 @@ deploy-extend-function:
 		--runtime go121 \
 		--trigger-http \
 		--allow-unauthenticated \
-		--memory 128MB \
+		--memory 128MiB \
 		--timeout 300s \
 		--service-account=$(SERVICE_ACCOUNT_EMAIL)
 	gcloud functions add-iam-policy-binding extend \
@@ -78,7 +78,7 @@ deploy-shutdown-function:
 		--entry-point ShutdownEntryPoint \
 		--runtime go121 \
 		--trigger-topic $(TOPIC_NAME) \
-		--memory 128MB \
+		--memory 128MiB \
 		--timeout 300s \
 		--service-account=$(SERVICE_ACCOUNT_EMAIL)
 

--- a/Makefile.slack
+++ b/Makefile.slack
@@ -57,7 +57,7 @@ deploy-function:
 		--runtime go121 \
 		--trigger-topic $(TOPIC_NAME) \
 		--set-env-vars GCP_PROJECT=$(GCP_PROJECT),CYBOZU_LOG_LEVEL=$(LOG_LEVEL) \
-		--memory 128MB \
+		--memory 128MiB \
 		--service-account=$(SERVICE_ACCOUNT_EMAIL)
 
 delete-function:


### PR DESCRIPTION
A container for Cloud Run must have at least 128 MiB.
ref https://cloud.google.com/run/docs/configuring/memory-limits