### PR TITLE
Run shutdown for multiple Zones

### DIFF
--- a/pkg/gcp/config.go
+++ b/pkg/gcp/config.go
@@ -134,6 +134,8 @@ func NecoTestConfig(projectID, zone string) *Config {
 				Timezone:   defaultTimeZone,
 				ShutdownAt: defaultAppShutdownAt,
 				AdditionalZones: []string{
+					"asia-northeast1-a",
+					"asia-northeast1-b",
 					"asia-northeast1-c",
 				},
 			},


### PR DESCRIPTION
This commit extends the target Zones of `shutdown` function
to include `asia-northeast1-a` and `asia-northeast1-b`,
because we need to change the Zone where we run `cybozu-go/neco`
CI tests.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
