### PR TITLE
vmxenabled: fix hostname check to allow prefix matching

### DIFF
--- a/cmd/setup/cmd/vmxenabled.go
+++ b/cmd/setup/cmd/vmxenabled.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"strings"
 
 	"github.com/cybozu-go/log"
 	necogcp "github.com/cybozu-go/neco-gcp"
@@ -26,7 +27,7 @@ Please run this command on vmx-enabled instance.`,
 			if err != nil {
 				return err
 			}
-			if hostname != "vmx-enabled" {
+			if !strings.HasPrefix(hostname, "vmx-enabled") {
 				return errors.New("this host is not supported")
 			}
 


### PR DESCRIPTION
From Ubuntu 26.04, hostname is FQDN of the instance.
This PR fix hostname check to allow prefix matching.